### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,24 @@ Summary
   oxc ran
    54.42 ± 2.78 times faster than eslint
 ```
+## 13th Gen Intel(R) i9-13980HX 24-cores (8p / 16e)
+```
+Benchmark 1: oxc
+  Time (mean ± σ):     458.9 ms ±   5.4 ms    [User: 5493.4 ms, System: 182.0 ms]
+  Range (min … max):   449.5 ms … 465.2 ms    10 runs
 
+  Warning: Ignoring non-zero exit code.
+
+Benchmark 2: eslint
+  Time (mean ± σ):     32.092 s ±  0.567 s    [User: 47.377 s, System: 2.207 s]
+  Range (min … max):   30.967 s … 32.752 s    10 runs
+
+  Warning: Ignoring non-zero exit code.
+
+Summary
+  oxc ran
+   69.93 ± 1.49 times faster than eslint
+```
 ## Run
 
 ```bash


### PR DESCRIPTION
Weird, it looks like a serious regression for OXC performance compared to my previous benchmark (28ms vs 450ms) and eslint is even worse (360ms vs 32s) 

Wonder if my previous bench results were valid 🤔