### PR TITLE
feat: add eslint --concurrency=auto benchmark variant

### DIFF
--- a/bench-sentry/bench.sh
+++ b/bench-sentry/bench.sh
@@ -18,4 +18,5 @@ ESLINT="./node_modules/.bin/eslint -c bench-sentry/eslint.config.mjs ${SENTRY_TE
 
 hyperfine -w 1 -i \
   -n oxc "${OXC}" \
-  -n eslint "${ESLINT}"
+  -n eslint "${ESLINT}" \
+  -n eslint-concurrency "${ESLINT} --concurrency=auto"

--- a/bench-vscode/README.md
+++ b/bench-vscode/README.md
@@ -18,7 +18,7 @@ Benchmarks for linting the Microsoft VS Code codebase with standard JavaScript/T
 ## Benchmarks Included
 
 1. **Oxlint vs Biome** - Single rule comparison (no-debugger)
-2. **Oxlint vs ESLint** - Full ruleset comparison with standard JS/TS rules
+2. **Oxlint vs ESLint** - Full ruleset comparison with standard JS/TS rules, with ESLint run both single-threaded (default) and multi-threaded (`--concurrency=auto`)
 
 ## Configuration Files
 

--- a/bench-vscode/bench.sh
+++ b/bench-vscode/bench.sh
@@ -27,4 +27,5 @@ ESLINT="../node_modules/.bin/eslint -c eslint.config.mjs ${VSCODE_TEST_DIR}"
 hyperfine -w 1 -i \
   -n oxc "${OXC}" \
   -n oxc-single-thread "${OXC} --threads=1" \
-  -n eslint "${ESLINT}"
+  -n eslint "${ESLINT}" \
+  -n eslint-concurrency "${ESLINT} --concurrency=auto"

--- a/bench-vue/README.md
+++ b/bench-vue/README.md
@@ -17,7 +17,7 @@ Benchmarks for linting the Vue.js Core codebase with type-aware TypeScript rules
 
 ## Benchmarks Included
 
-**Oxlint vs TypeScript ESLint** - Type-aware rules comparison
+**Oxlint vs TypeScript ESLint** - Type-aware rules comparison, with ESLint run both single-threaded (default) and multi-threaded (`--concurrency=auto`)
 
 ## Configuration Files
 

--- a/bench-vue/bench.sh
+++ b/bench-vue/bench.sh
@@ -17,4 +17,5 @@ ESLINT="./node_modules/.bin/eslint -c bench-vue/eslint.config.mjs ${VUE_CORE_TES
 
 hyperfine -w 1 -i \
   -n oxc "${OXC}" \
-  -n eslint "${ESLINT}"
+  -n eslint "${ESLINT}" \
+  -n eslint-concurrency "${ESLINT} --concurrency=auto"


### PR DESCRIPTION
Adds an `eslint-concurrency` run (`--concurrency=auto`) to all three benchmark suites for a fairer multi-core comparison against oxlint, which is multi-threaded by default. The locked ESLint version (10.6.0) already supports the flag, so no dependency changes are needed.

Result blocks in the root README are left untouched until the benchmarks are re-run.

Closes #54